### PR TITLE
Fix package import alias

### DIFF
--- a/src/ma_framework/__init__.py
+++ b/src/ma_framework/__init__.py
@@ -1,0 +1,15 @@
+"""Compatibility wrapper for the legacy ``ma_framework`` import path."""
+from __future__ import annotations
+import sys
+import mimi3
+
+# Re-export the public API of mimi3
+from mimi3 import *  # noqa: F401,F403
+
+# Register submodules under this package name for backwards compatibility
+sys.modules[__name__ + ".models"] = mimi3.models
+sys.modules[__name__ + ".schemas"] = mimi3.schemas
+sys.modules[__name__ + ".database"] = mimi3.database
+sys.modules[__name__ + ".tools"] = mimi3.tools
+sys.modules[__name__ + ".agents"] = mimi3.agents
+sys.modules[__name__ + ".crud"] = mimi3.crud

--- a/src/mimi3/__init__.py
+++ b/src/mimi3/__init__.py
@@ -8,7 +8,8 @@ __version__ = "0.1.0"
 from . import models
 from . import schemas
 from . import database
+from . import crud
 from . import tools
 from . import agents
 
-__all__ = ["models", "schemas", "database", "tools", "agents"]
+__all__ = ["models", "schemas", "database", "crud", "tools", "agents"]


### PR DESCRIPTION
## Summary
- expose `crud` in `mimi3.__init__`
- add `ma_framework` compatibility package to keep old import paths working

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c1319cc14832ca036a558aed7b298