### PR TITLE
Fix docstring spelling

### DIFF
--- a/src/mimi3/agents/builder_agent.py
+++ b/src/mimi3/agents/builder_agent.py
@@ -1,4 +1,4 @@
-"""BuilderAgent specialising in code generation."""
+"""BuilderAgent specializing in code generation."""
 from crewai import Task
 from .base import MultiModelAgent
 

--- a/src/mimi3/agents/reviewer_agent.py
+++ b/src/mimi3/agents/reviewer_agent.py
@@ -1,4 +1,4 @@
-"""ReviewerAgent specialising in code review."""
+"""ReviewerAgent specializing in code review."""
 from crewai import Task
 from .base import MultiModelAgent
 


### PR DESCRIPTION
## Summary
- fix 'specialising' to 'specializing' in Builder and Reviewer agent docs

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'ma_framework')*

------
https://chatgpt.com/codex/tasks/task_e_684c15c48d6c832ca164014b9f1bb4d1