### PR TITLE
Update CLI help text

### DIFF
--- a/src/mimi3/cli.py
+++ b/src/mimi3/cli.py
@@ -4,7 +4,7 @@ from .database import init_db, SessionLocal
 from .crud import create_role, create_model, create_tool
 from . import models
 
-app = typer.Typer(help="ma_framework CLI")
+app = typer.Typer(help="MiMi-3 CLI")
 
 @app.command()
 def initdb() -> None:


### PR DESCRIPTION
## Summary
- update Typer help text to reference MiMi-3

## Testing
- `pytest -q` *(fails: No module named 'ma_framework')*

------
https://chatgpt.com/codex/tasks/task_e_684c15c698e0832ca43e7c26c5f286a3